### PR TITLE
Update and add package references

### DIFF
--- a/src/EditorBar/JPSoftworks.EditorBar.csproj
+++ b/src/EditorBar/JPSoftworks.EditorBar.csproj
@@ -151,7 +151,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Community.VisualStudio.Toolkit.17">
-      <Version>17.0.507</Version>
+      <Version>17.0.527</Version>
     </PackageReference>
     <PackageReference Include="Community.VisualStudio.VSCT">
       <Version>16.0.29.6</Version>
@@ -159,10 +159,15 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="JetBrains.Annotations">
-      <Version>2023.3.0</Version>
+      <Version>2024.3.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.12.40392" ExcludeAssets="runtime">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.12.2069">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Page Include="Controls\ColorButton.xaml">


### PR DESCRIPTION
Update and add package references

- `Community.VisualStudio.Toolkit.17` from `17.0.507` to `17.0.527`
- `JetBrains.Annotations` from `2023.3.0` to `2024.3.0`
- `Microsoft.VisualStudio.SDK` version `17.12.40392`
- `Microsoft.VSSDK.BuildTools` version `17.12.2069`