### PR TITLE
Set breadcrumbs separator shape fill brush explictly to transparent

### DIFF
--- a/src/EditorBar/Themes/Generic.ChevronButton.xaml
+++ b/src/EditorBar/Themes/Generic.ChevronButton.xaml
@@ -68,6 +68,7 @@
                             <Path x:Name="PART_Separator" Data="M0,0 5,15 0,30"
                                   Visibility="{Binding ShowRightBorder, RelativeSource={RelativeSource FindAncestor, AncestorType=controls:SymbolChevronButton}, Converter={StaticResource BooleanToVisibilityConverter}}"
                                   Stroke="{Binding RightBorderBrush, RelativeSource={RelativeSource FindAncestor, AncestorType=controls:SymbolChevronButton}}"
+                                  Fill="Transparent"
                                   Stretch="Fill"
                                   StrokeThickness="1"
                                   VerticalAlignment="Stretch" StrokeStartLineCap="Round" StrokeEndLineCap="Round"


### PR DESCRIPTION
Set breadcrumbs separator shape fill brush explictly to transparent

Fixes: #67