### PR TITLE
Hotfix VS incorrectly changing focus after navgation

### DIFF
--- a/src/EditorBar/Controls/EditorBarControl.xaml
+++ b/src/EditorBar/Controls/EditorBarControl.xaml
@@ -35,13 +35,16 @@
                                 ToolTip="Debug"
                                 Style="{DynamicResource NoBorderButtonStyle}"
                                 Visibility="{Binding IsDevelopmentModeEnabled, Converter={StaticResource BooleanToVisibilityConverter} }"
-                                TabIndex="2">
+                                TabIndex="2"
+                                PreviewGotKeyboardFocus="UIElement_OnPreviewGotKeyboardFocus">
                             <imaging:CrispImage Moniker="{x:Static catalog:KnownMonikers.StatusInformation}" />
                         </Button>
                         <Button Command="{Binding OpenDefaultEditorCommand }"
                                 ToolTip="Open in Default Editor"
                                 Style="{DynamicResource NoBorderButtonStyle}"
-                                TabIndex="3">
+                                TabIndex="3"
+                                PreviewGotKeyboardFocus="UIElement_OnPreviewGotKeyboardFocus"
+                                >
                             <imaging:CrispImage Moniker="{x:Static catalog:KnownMonikers.OpenFileDialog}" />
                         </Button>
                         <Button x:Name="OpenExternalEditorButton"


### PR DESCRIPTION
This PR hotfixes an issue where Visual Studio incorrectly focuses the Editor Bar after changing the active tab.

The fix ensures that when focus lands on the first tab navigation control in the Editor Bar without coming from its neighbor, the focus change is ignored, and focus is redirected to the text view instead.

Fixed: #74 