### PR TITLE
Implement code analysis upgrade in a backwards compatible manner

### DIFF
--- a/src/EditorBar/Helpers/CodeAnalysis/FileStructureHelper.cs
+++ b/src/EditorBar/Helpers/CodeAnalysis/FileStructureHelper.cs
@@ -225,15 +225,20 @@ internal static class FileStructureHelper
                     anchorPoint);
 
             case INamedTypeSymbol typeSymbol:
-                return new TypeModel(
-                    typeSymbol.ToDisplayString(SymbolFileStructureElementModel.SymbolDisplayFormat),
-                    VsImageHelper.GetImageMonikers(anchorPoint.Symbol.GetImageId()),
-                    anchorPoint,
-                    typeSymbol.GetFullMetadataName())
                 {
-                    CanHaveChildren = typeSymbol.TypeKind is TypeKind.Class or TypeKind.Interface or TypeKind.Struct
-                        or TypeKind.Enum or TypeKind.Module or TypeKind.Extension
-                };
+                    var canHaveChildren = typeSymbol.TypeKind is TypeKind.Class or TypeKind.Interface or TypeKind.Struct
+                        or TypeKind.Enum or TypeKind.Module
+                        || typeSymbol.IsExtensionType();
+
+                    return new TypeModel(
+                        typeSymbol.ToDisplayString(SymbolFileStructureElementModel.SymbolDisplayFormat),
+                        VsImageHelper.GetImageMonikers(anchorPoint.Symbol.GetImageId()),
+                        anchorPoint,
+                        typeSymbol.GetFullMetadataName())
+                    {
+                        CanHaveChildren = canHaveChildren
+                    };
+                }
 
             default:
                 return null;

--- a/src/EditorBar/Helpers/CodeAnalysis/IconProviderForCodeAnalysis.cs
+++ b/src/EditorBar/Helpers/CodeAnalysis/IconProviderForCodeAnalysis.cs
@@ -125,18 +125,15 @@ public static class IconProviderForCodeAnalysis
 
         static int GetTypeImageId(INamedTypeSymbol t)
         {
+            if (t.IsExtensionType())
+            {
+                return GetClassLikeTypeImageId(t);
+            }
+
             switch (t.TypeKind)
             {
-                case TypeKind.Extension:
                 case TypeKind.Class:
-                    return t.DeclaredAccessibility switch
-                    {
-                        Accessibility.Public => KnownImageIds.ClassPublic,
-                        Accessibility.Protected or Accessibility.ProtectedOrInternal => KnownImageIds.ClassProtected,
-                        Accessibility.Private => KnownImageIds.ClassPrivate,
-                        Accessibility.ProtectedAndInternal or Accessibility.Internal => KnownImageIds.ClassInternal,
-                        _ => IconIds.Class
-                    };
+                    return GetClassLikeTypeImageId(t);
                 case TypeKind.Delegate:
                     return t.DeclaredAccessibility switch
                     {
@@ -209,6 +206,18 @@ public static class IconProviderForCodeAnalysis
                 case TypeKind.FunctionPointer:
                 default:
                     return KnownImageIds.StatusError;
+            }
+
+            static int GetClassLikeTypeImageId(INamedTypeSymbol typeSymbol)
+            {
+                return typeSymbol.DeclaredAccessibility switch
+                {
+                    Accessibility.Public => KnownImageIds.ClassPublic,
+                    Accessibility.Protected or Accessibility.ProtectedOrInternal => KnownImageIds.ClassProtected,
+                    Accessibility.Private => KnownImageIds.ClassPrivate,
+                    Accessibility.ProtectedAndInternal or Accessibility.Internal => KnownImageIds.ClassInternal,
+                    _ => IconIds.Class
+                };
             }
         }
 

--- a/src/EditorBar/Helpers/CodeAnalysis/RoslynCompatibilityHelper.cs
+++ b/src/EditorBar/Helpers/CodeAnalysis/RoslynCompatibilityHelper.cs
@@ -1,0 +1,44 @@
+// ------------------------------------------------------------
+//
+// Copyright (c) Jiří Polášek. All rights reserved.
+//
+// ------------------------------------------------------------
+
+#nullable enable
+
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+
+namespace JPSoftworks.EditorBar.Helpers;
+
+internal static class RoslynCompatibilityHelper
+{
+    private const string ExtensionBlockDeclarationSyntaxName = "ExtensionBlockDeclarationSyntax";
+    private const string ExtensionTypeKindName = "Extension";
+
+    internal static bool IsExtensionType(this INamedTypeSymbol typeSymbol)
+    {
+        return typeSymbol.TypeKind.ToString() == ExtensionTypeKindName;
+    }
+
+    internal static bool TryGetExtensionBlockKeyword(this SyntaxNode syntaxNode, out SyntaxToken keyword)
+    {
+        if (syntaxNode.Language != LanguageNames.CSharp ||
+            syntaxNode.GetType().Name != ExtensionBlockDeclarationSyntaxName)
+        {
+            keyword = default;
+            return false;
+        }
+
+        var keywordProperty = syntaxNode.GetType().GetProperty("Keyword", BindingFlags.Public | BindingFlags.Instance);
+        if (keywordProperty?.GetValue(syntaxNode) is not SyntaxToken extensionKeyword ||
+            extensionKeyword == default)
+        {
+            keyword = default;
+            return false;
+        }
+
+        keyword = extensionKeyword;
+        return true;
+    }
+}

--- a/src/EditorBar/JPSoftworks.EditorBar.csproj
+++ b/src/EditorBar/JPSoftworks.EditorBar.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Helpers\CodeAnalysis\FileStructureHelper.cs" />
     <Compile Include="Helpers\Events\GenericEventSource.cs" />
     <Compile Include="Helpers\CodeAnalysis\IconProviderForCodeAnalysis.cs" />
+    <Compile Include="Helpers\CodeAnalysis\RoslynCompatibilityHelper.cs" />
     <Compile Include="Helpers\IconIds.cs" />
     <Compile Include="Controls\LegacyFileLabel.xaml.cs">
       <DependentUpon>LegacyFileLabel.xaml</DependentUpon>
@@ -345,13 +346,13 @@
       <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>5.0.0</Version>
+      <Version>4.4.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Text">
-      <Version>4.14.0</Version>
+      <Version>4.4.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic">
-      <Version>5.0.0</Version>
+      <Version>4.4.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IO.Redist">
       <Version>6.1.0</Version>

--- a/src/EditorBar/Services/CodeNavigationService.cs
+++ b/src/EditorBar/Services/CodeNavigationService.cs
@@ -94,24 +94,25 @@ internal class CodeNavigationService : ICodeNavigationService, ITextNavigationSe
     {
         // Safely pattern-match to get the token for the identifier
         // You can expand this switch expression for other node types if needed
-        var targetToken = syntaxNode switch
-        {
-            MethodDeclarationSyntax methodDecl => methodDecl.Identifier,
-            ConstructorDeclarationSyntax ctorDecl => ctorDecl.Identifier,
-            PropertyDeclarationSyntax propertyDecl => propertyDecl.Identifier,
-            EventDeclarationSyntax eventDecl => eventDecl.Identifier,
-            FieldDeclarationSyntax fieldDecl => fieldDecl.Declaration.Variables.First().Identifier,
-            EventFieldDeclarationSyntax eventField => eventField.Declaration.Variables.First().Identifier,
-            ExtensionBlockDeclarationSyntax extensionDecl => extensionDecl.Keyword,
-            TypeDeclarationSyntax typeDecl => typeDecl.Identifier, // classes, structs, records
-            EnumDeclarationSyntax enumDecl => enumDecl.Identifier,
-            DelegateDeclarationSyntax delegateDecl => delegateDecl.Identifier,
-            // fallback: just pick the first token if none of the above
-            _ => syntaxNode.GetFirstToken()
-        };
+        var targetToken = syntaxNode.TryGetExtensionBlockKeyword(out var extensionKeyword)
+            ? extensionKeyword
+            : syntaxNode switch
+            {
+                MethodDeclarationSyntax methodDecl => methodDecl.Identifier,
+                ConstructorDeclarationSyntax ctorDecl => ctorDecl.Identifier,
+                PropertyDeclarationSyntax propertyDecl => propertyDecl.Identifier,
+                EventDeclarationSyntax eventDecl => eventDecl.Identifier,
+                FieldDeclarationSyntax fieldDecl => fieldDecl.Declaration.Variables.First().Identifier,
+                EventFieldDeclarationSyntax eventField => eventField.Declaration.Variables.First().Identifier,
+                TypeDeclarationSyntax typeDecl => typeDecl.Identifier, // classes, structs, records
+                EnumDeclarationSyntax enumDecl => enumDecl.Identifier,
+                DelegateDeclarationSyntax delegateDecl => delegateDecl.Identifier,
+                // fallback: just pick the first token if none of the above
+                _ => syntaxNode.GetFirstToken()
+            };
 
         // The start of the identifier token in the overall file
-        if (targetToken != null)
+        if (targetToken != default)
         {
             // TODO: check the file path, if it's different, then we have to open new view with the target file
             var isSameFile = this.IsInCurrentFile(syntaxNode);

--- a/src/EditorBar/Services/StructureProviders/Roslyn/RoslynWorkspaceFileStructureProvider.cs
+++ b/src/EditorBar/Services/StructureProviders/Roslyn/RoslynWorkspaceFileStructureProvider.cs
@@ -239,25 +239,14 @@ internal class RoslynWorkspaceFileStructureProvider
 
         var node = root.FindNode(anchorSpan, getInnermostNodeForTie: true);
 
-        // 1) If this TypeModel is an extension block, this finds it reliably.
-        var extensionDecl = node.FirstAncestorOrSelf<ExtensionBlockDeclarationSyntax>();
-        if (extensionDecl is not null)
+        // Resolve the nearest declared type from the anchor so newer Roslyn nodes
+        // (for example extension blocks) keep working even when we compile against an older API surface.
+        foreach (var candidate in node.AncestorsAndSelf())
         {
-            return semanticModel.GetDeclaredSymbol(extensionDecl) as INamedTypeSymbol;
-        }
-
-        // 2) Normal types (class/struct/record/interface/etc.)
-        var typeDecl = node.FirstAncestorOrSelf<TypeDeclarationSyntax>();
-        if (typeDecl is not null)
-        {
-            return semanticModel.GetDeclaredSymbol(typeDecl) as INamedTypeSymbol;
-        }
-
-        // 3) Other "type-like" declarations if you model them as TypeModel
-        var enumDecl = node.FirstAncestorOrSelf<EnumDeclarationSyntax>();
-        if (enumDecl is not null)
-        {
-            return semanticModel.GetDeclaredSymbol(enumDecl) as INamedTypeSymbol;
+            if (semanticModel.GetDeclaredSymbol(candidate) is INamedTypeSymbol declaredTypeSymbol)
+            {
+                return declaredTypeSymbol;
+            }
         }
 
         return null;

--- a/src/EditorBar/source.extension.vsixmanifest
+++ b/src/EditorBar/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" ?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="EditorBar.d5a61a21-bc87-477e-b916-ead20fb3fafb" Version="3.0.1024" Language="en-US" Publisher="Jiří Polášek" />
+        <Identity Id="EditorBar.d5a61a21-bc87-477e-b916-ead20fb3fafb" Version="3.1.0" Language="en-US" Publisher="Jiří Polášek" />
         <DisplayName>Editor Bar</DisplayName>
         <Description xml:space="preserve">Adds intuitive breadcrumbs to help you navigate file paths and code structure with ease.</Description>
         <MoreInfo>https://jiripolasek.com</MoreInfo>


### PR DESCRIPTION
This PR fixes compatibility with VS2022 that regressed with upgrade of Microsoft.CodeAnalysis.* packages.