### PR TITLE
Fix memory leak in LegacyLabelViewModel from static event subscription

### DIFF
--- a/src/EditorBar/ViewModels/LegacyLabelViewModel.cs
+++ b/src/EditorBar/ViewModels/LegacyLabelViewModel.cs
@@ -17,7 +17,7 @@ using Microsoft.VisualStudio.Text;
 
 namespace JPSoftworks.EditorBar.ViewModels;
 
-internal class LegacyLabelViewModel : ObservableObject
+internal class LegacyLabelViewModel : ObservableObject, IDisposable
 {
     private string? _label;
     private LocationNavModel? _locationNavModel;
@@ -70,6 +70,11 @@ internal class LegacyLabelViewModel : ObservableObject
 
         GeneralOptionsModel.Saved += this.GeneralOptionsModelOnSaved;
         this.Style = GeneralOptionsModel.Instance.FileLabelStyle;
+    }
+
+    public void Dispose()
+    {
+        GeneralOptionsModel.Saved -= this.GeneralOptionsModelOnSaved;
     }
 
     private void GeneralOptionsModelOnSaved(GeneralOptionsModel obj)

--- a/src/EditorBar/ViewModels/LocationBreadcrumbsViewModel.cs
+++ b/src/EditorBar/ViewModels/LocationBreadcrumbsViewModel.cs
@@ -121,7 +121,8 @@ internal class LocationBreadcrumbsViewModel : ObservableObject, IDisposable
 
     public void Dispose()
     {
-        this._settingsRefreshAggregator.Dispose();
+        this._settingsRefreshAggregator.SettingsRefreshRequested -= this.HandleSettingsChanged;
+        this.LegacyLabelModel.Dispose();
         this._disposables.Dispose();
     }
 


### PR DESCRIPTION
 LegacyLabelViewModel subscribed to the static GeneralOptionsModel.Saved
 event but never unsubscribed, causing instances to be rooted for the
 lifetime of the process. Every editor tab opened leaked a ViewModel.

 - Implement IDisposable on LegacyLabelViewModel to unsubscribe from GeneralOptionsModel.Saved
 - Dispose LegacyLabelModel from LocationBreadcrumbsViewModel.Dispose()
 - Stop disposing the non-owned SettingsRefreshAggregator in LocationBreadcrumbsViewModel; unsubscribe the event handler instead

Fixes #96 