### PR TITLE
 Add graceful degradation when structural breadcrumbs cannot initialize

### DIFF
--- a/src/EditorBar/Controls/EditorBarControlContainer.xaml.cs
+++ b/src/EditorBar/Controls/EditorBarControlContainer.xaml.cs
@@ -61,17 +61,37 @@ internal partial class EditorBarControlContainer : IDisposable
             var textDocument = this._textView.GetTextDocumentFromDocumentBuffer();
             if (textDocument != null)
             {
-                this.Content = new EditorBarControl(
-                    this._textView,
-                    textDocument,
-                    this._joinableTaskFactory,
-                    this._structureProviderService);
-                return;
+                try
+                {
+                    this.Content = new EditorBarControl(
+                        this._textView,
+                        textDocument,
+                        this._joinableTaskFactory,
+                        this._structureProviderService);
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    ex.Log();
+                    this.Content = CreateFallbackContent(textDocument.FilePath);
+                    return;
+                }
             }
         }
 
         this.DisposeCurrentContent();
         this.Content = null!;
+    }
+
+    private static UIElement CreateFallbackContent(string? filePath)
+    {
+        return new System.Windows.Controls.TextBlock
+        {
+            Text = filePath ?? "(unknown file)",
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(6, 2, 6, 2),
+            TextTrimming = TextTrimming.CharacterEllipsis
+        };
     }
 
     private void DisposeCurrentContent()

--- a/src/EditorBar/ViewModels/EditorBarViewModel.cs
+++ b/src/EditorBar/ViewModels/EditorBarViewModel.cs
@@ -38,7 +38,7 @@ internal class EditorBarViewModel : ObservableObject, IDisposable
 
     public LocationBreadcrumbsViewModel LocationBreadcrumbs { get; }
 
-    public StructuralBreadcrumbsViewModel StructuralBreadcrumbs { get; }
+    public StructuralBreadcrumbsViewModel? StructuralBreadcrumbs { get; }
 
     public BulkObservableCollection<BreadcrumbModel> Breadcrumbs { get; } = [];
 
@@ -100,14 +100,21 @@ internal class EditorBarViewModel : ObservableObject, IDisposable
             += (_, _) => this.CombineBreadcrumbsAsync().FireAndForget();
         this.LocationBreadcrumbs.AddTo(this._disposables);
 
-        this.StructuralBreadcrumbs = new StructuralBreadcrumbsViewModel(
-            textView,
-            this._workspaceMonitor,
-            structureProviderService,
-            settingsRefreshAggregator);
-        this.StructuralBreadcrumbs.StructuralBreadcrumbs.CollectionChanged
-            += (_, _) => this.CombineBreadcrumbsAsync().FireAndForget();
-        this.StructuralBreadcrumbs.AddTo(this._disposables);
+        try
+        {
+            this.StructuralBreadcrumbs = new StructuralBreadcrumbsViewModel(
+                textView,
+                this._workspaceMonitor,
+                structureProviderService,
+                settingsRefreshAggregator);
+            this.StructuralBreadcrumbs.StructuralBreadcrumbs.CollectionChanged
+                += (_, _) => this.CombineBreadcrumbsAsync().FireAndForget();
+            this.StructuralBreadcrumbs.AddTo(this._disposables);
+        }
+        catch (Exception ex)
+        {
+            ex.Log();
+        }
 
         this.ShowDebugInformationCommand = new DispatchedDelegateCommand(this.ExecuteShowDebugInfo);
         this.OpenContainingFolderCommand
@@ -122,8 +129,26 @@ internal class EditorBarViewModel : ObservableObject, IDisposable
 
     public async Task InitializeAsync()
     {
-        await this.LocationBreadcrumbs.InitializeAsync();
-        await this.StructuralBreadcrumbs.InitializeAsync();
+        try
+        {
+            await this.LocationBreadcrumbs.InitializeAsync();
+        }
+        catch (Exception ex)
+        {
+            await ex.LogAsync();
+        }
+
+        try
+        {
+            if (this.StructuralBreadcrumbs != null)
+            {
+                await this.StructuralBreadcrumbs.InitializeAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            await ex.LogAsync();
+        }
     }
 
     /// <inheritdoc />
@@ -188,7 +213,7 @@ internal class EditorBarViewModel : ObservableObject, IDisposable
         BreadcrumbModel[] breadcrumbs =
         [
             .. this.LocationBreadcrumbs.LocationBreadcrumbs,
-            .. this.StructuralBreadcrumbs.StructuralBreadcrumbs
+            .. this.StructuralBreadcrumbs?.StructuralBreadcrumbs ?? []
         ];
         this.Breadcrumbs.SetRange(breadcrumbs);
     }

--- a/src/EditorBar/ViewModels/StructuralBreadcrumbsViewModel.cs
+++ b/src/EditorBar/ViewModels/StructuralBreadcrumbsViewModel.cs
@@ -56,7 +56,8 @@ internal class StructuralBreadcrumbsViewModel : ObservableObject, IDisposable
         this._structureProviderService = Requires.NotNull(structureProviderService);
         Requires.NotNull(settingsRefreshAggregator);
 
-        this._document = this._textView.GetTextDocumentFromDocumentBuffer()!;
+        this._document = this._textView.GetTextDocumentFromDocumentBuffer()
+            ?? throw new InvalidOperationException("Text view has no associated text document.");
         this._pathChangesStream = Observable
             .Defer(() => Observable.Return(this._document.FilePath))
             .Concat(


### PR DESCRIPTION
 StructuralBreadcrumbsViewModel fails if the text view has no associated document buffer, previously crashing the entire editor bar.

 - Replace null-suppression on _document with an explicit exception
 - Make StructuralBreadcrumbs nullable in EditorBarViewModel; wrap creation in try/catch so location breadcrumbs and toolbar still work
 - Isolate LocationBreadcrumbs and StructuralBreadcrumbs initialization so one failing does not block the other
 - Add ultimate fallback in EditorBarControlContainer: if EditorBarControl creation fails entirely, show a plain TextBlock with the file path

Closes #98