### PR TITLE
Ffix file breadcrumbs missing children after opening

### DIFF
--- a/src/EditorBar/Services/StructureProviders/Abstractions/BaseStructureModel.cs
+++ b/src/EditorBar/Services/StructureProviders/Abstractions/BaseStructureModel.cs
@@ -67,7 +67,8 @@ public abstract class BaseStructureModel : IEquatable<BaseStructureModel>
             return true;
         }
 
-        return this.AnchorPoint.FilePath == other.AnchorPoint.FilePath
+        return this.CanHaveChildren == other.CanHaveChildren
+               && this.AnchorPoint.FilePath == other.AnchorPoint.FilePath
                && this.DisplayName == other.DisplayName
                && Equals(this.AnchorPoint, other.AnchorPoint);
     }
@@ -103,7 +104,11 @@ public abstract class BaseStructureModel : IEquatable<BaseStructureModel>
     /// <returns>An integer hash code.</returns>
     public override int GetHashCode()
     {
-        return HashCode.Combine(this.AnchorPoint.FilePath, this.DisplayName, this.AnchorPoint);
+        return HashCode.Combine(
+            this.CanHaveChildren,
+            this.AnchorPoint.FilePath,
+            this.DisplayName,
+            this.AnchorPoint);
     }
 
     /// <summary>

--- a/src/EditorBar/ViewModels/StructuralBreadcrumbsViewModel.cs
+++ b/src/EditorBar/ViewModels/StructuralBreadcrumbsViewModel.cs
@@ -289,6 +289,7 @@ internal class StructuralBreadcrumbsViewModel : ObservableObject, IDisposable
 
     public Task InitializeAsync()
     {
+        this.UpdateFileStructureProvider();
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
This PR ensure that we correctly detect change in breadcrumb children availability (fixing children breadcrumbs not being present), and that adds extra refresh after initialization (to ensure that structural breadcrumbs are expanded to match element at caret position).

Closes: #132 