### PR TITLE
Add new position: next to the zoom

### DIFF
--- a/src/EditorBar/Commands/Settings/SettingsSetPositionBottomControlCommand.cs
+++ b/src/EditorBar/Commands/Settings/SettingsSetPositionBottomControlCommand.cs
@@ -1,0 +1,29 @@
+// ------------------------------------------------------------
+// Copyright (c) Jiří Polášek. All rights reserved.
+// ------------------------------------------------------------
+
+#nullable enable
+
+using Community.VisualStudio.Toolkit;
+using JPSoftworks.EditorBar.Commands.Abstractions;
+using JPSoftworks.EditorBar.Options;
+
+namespace JPSoftworks.EditorBar.Commands;
+
+[Command(PackageGuids.EditorBarCmdSetString, PackageIds.EditorBarSettings_PositionBottomControlCommand)]
+[UsedImplicitly]
+internal sealed class SettingsSetPositionBottomControlCommand
+    : BaseMenuContextCommand<SettingsMenuContext, SettingsSetPositionBottomControlCommand>
+{
+    protected override void BeforeQueryStatus(EventArgs e)
+    {
+        base.BeforeQueryStatus(e);
+        this.Command.Checked = GeneralOptionsModel.Instance.BarPosition == BarPosition.BottomControl;
+    }
+
+    protected override async Task ExecuteCoreAsync(SettingsMenuContext context)
+    {
+        GeneralOptionsModel.Instance.BarPosition = BarPosition.BottomControl;
+        await GeneralOptionsModel.Instance.SaveAsync();
+    }
+}

--- a/src/EditorBar/Controls/EditorBarControl.xaml
+++ b/src/EditorBar/Controls/EditorBarControl.xaml
@@ -29,7 +29,10 @@
         <Border x:Name="EditorBarBorder" Style="{DynamicResource EditorBarBorderStyle}">
             <DockPanel VerticalAlignment="Center" KeyboardNavigation.TabNavigation="Local">
 
-                <Border DockPanel.Dock="Right" Style="{StaticResource CommandBarBorderStyle}">
+                <Border
+                    DockPanel.Dock="Right"
+                    Style="{StaticResource CommandBarBorderStyle}"
+                    Visibility="{Binding ElementName=RootControl, Path=UsesStandardToolbar, Converter={StaticResource BooleanToVisibilityConverter}}">
 
                     <StackPanel
                         KeyboardNavigation.TabIndex="2"
@@ -85,6 +88,30 @@
                         </Button>
                         <Button
                             x:Name="SettingsMenuButton"
+                            Click="SettingsMenuButton_OnClick"
+                            Style="{DynamicResource NoBorderButtonStyle}"
+                            ToolTip="Options">
+                            <imaging:CrispImage Moniker="{x:Static catalog:KnownMonikers.Settings}" />
+                        </Button>
+                    </StackPanel>
+
+                </Border>
+
+                <Border
+                    DockPanel.Dock="Right"
+                    Visibility="{Binding ElementName=RootControl, Path=UsesToolbarOverflow, Converter={StaticResource BooleanToVisibilityConverter}}">
+
+                    <StackPanel
+                        KeyboardNavigation.TabIndex="2"
+                        KeyboardNavigation.TabNavigation="Local"
+                        Orientation="Horizontal">
+                        <Button
+                            Click="FileActionsMenuButton_OnClick"
+                            Style="{DynamicResource NoBorderButtonStyle}"
+                            ToolTip="More file actions">
+                            <imaging:CrispImage Moniker="{x:Static catalog:KnownMonikers.Ellipsis}" />
+                        </Button>
+                        <Button
                             Click="SettingsMenuButton_OnClick"
                             Style="{DynamicResource NoBorderButtonStyle}"
                             ToolTip="Options">

--- a/src/EditorBar/Controls/EditorBarControl.xaml.cs
+++ b/src/EditorBar/Controls/EditorBarControl.xaml.cs
@@ -36,8 +36,19 @@ internal partial class EditorBarControl : IDisposable
     private readonly CompositeDisposable _disposables = [];
     private readonly JoinableTaskFactory _joinableTaskFactory;
     private readonly BarPosition _position;
+    private readonly ITextDocument _textDocument;
     private readonly IWpfTextView _textView;
     private readonly EditorBarViewModel _viewModel;
+
+    /// <summary>
+    /// Gets a value indicating whether file actions should use the compact overflow surface.
+    /// </summary>
+    public bool UsesToolbarOverflow => this._position == BarPosition.BottomControl;
+
+    /// <summary>
+    /// Gets a value indicating whether file actions should use the standard toolbar surface.
+    /// </summary>
+    public bool UsesStandardToolbar => !this.UsesToolbarOverflow;
 
     public EditorBarControl(
         IWpfTextView textView,
@@ -49,7 +60,7 @@ internal partial class EditorBarControl : IDisposable
         this._textView = Requires.NotNull(textView);
         this._joinableTaskFactory = Requires.NotNull(joinableTaskFactory);
         this._position = position;
-        Requires.NotNull(textDocument);
+        this._textDocument = Requires.NotNull(textDocument);
         Requires.NotNull(structureProviderService);
 
         this.DataContext = this._viewModel =
@@ -247,5 +258,10 @@ internal partial class EditorBarControl : IDisposable
     private void SettingsMenuButton_OnClick(object sender, RoutedEventArgs e)
     {
         new SettingsMenuContext(this._textView).ShowMenu();
+    }
+
+    private void FileActionsMenuButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        new FileActionMenuContext(this._textDocument).ShowMenu();
     }
 }

--- a/src/EditorBar/Controls/EditorBarControl.xaml.cs
+++ b/src/EditorBar/Controls/EditorBarControl.xaml.cs
@@ -35,6 +35,7 @@ internal partial class EditorBarControl : IDisposable
     private readonly SingleActionGatedExecutor _delayedSettingsApplicator;
     private readonly CompositeDisposable _disposables = [];
     private readonly JoinableTaskFactory _joinableTaskFactory;
+    private readonly BarPosition _position;
     private readonly IWpfTextView _textView;
     private readonly EditorBarViewModel _viewModel;
 
@@ -42,10 +43,12 @@ internal partial class EditorBarControl : IDisposable
         IWpfTextView textView,
         ITextDocument textDocument,
         JoinableTaskFactory joinableTaskFactory,
-        IStructureProviderService structureProviderService)
+        IStructureProviderService structureProviderService,
+        BarPosition position)
     {
         this._textView = Requires.NotNull(textView);
         this._joinableTaskFactory = Requires.NotNull(joinableTaskFactory);
+        this._position = position;
         Requires.NotNull(textDocument);
         Requires.NotNull(structureProviderService);
 
@@ -108,38 +111,48 @@ internal partial class EditorBarControl : IDisposable
 
         this.ReloadThemeResources();
 
-        // allow to change background color of the editor bar
-        // in case of the top panel, we can follow the color of the editor so it integrates seamlessly;
-        // bottom panel is below the scrollbar, so it doesn't make sense to follow the editor color
-        if (GeneralOptionsModel.Instance.BarPosition == BarPosition.Top)
+        // Allow the top bar to follow the editor appearance. Bottom positions use the chrome of their actual host.
+        switch (this._position)
         {
-            switch (GeneralOptionsModel.Instance.VisualStyle)
-            {
-                case VisualStyle.FullRowCommandBar:
-                    this.Background = (Brush)this.FindResource(VsBrushes.CommandBarGradientKey!)!;
-                    this.BorderBrush = (Brush)this.FindResource(SearchControlColors.PopupBorderBrushKey!)!;
-                    this.BorderThickness = new Thickness(0, 0, 0, 1);
-                    break;
-                case VisualStyle.FullRowTransparent:
-                    // copy background from the editor so the theme ImageThemingUtilities.ImageBackgroundColor will work
-                    this.Background = this._textView.Background ?? Brushes.Transparent;
-                    this.BorderBrush = (Brush)this.FindResource(SearchControlColors.PopupBorderBrushKey!)!;
-                    this.BorderThickness = new Thickness(0, 0, 0, 1);
-                    break;
-                case VisualStyle.FullRowToolWindow:
-                    this.Background = (Brush)this.FindResource(VsBrushes.ToolWindowBackgroundKey!)!;
-                    this.BorderBrush = (Brush)this.FindResource(SearchControlColors.PopupBorderBrushKey!)!;
-                    this.BorderThickness = new Thickness(0, 0, 0, 1);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
-        else
-        {
-            this.Background = (Brush)this.FindResource(VsBrushes.CommandBarGradientKey!)!;
-            this.BorderBrush = Brushes.Transparent;
-            this.BorderThickness = new Thickness(0);
+            case BarPosition.Top:
+                switch (GeneralOptionsModel.Instance.VisualStyle)
+                {
+                    case VisualStyle.FullRowCommandBar:
+                        this.Background = (Brush)this.FindResource(VsBrushes.CommandBarGradientKey!)!;
+                        this.BorderBrush = (Brush)this.FindResource(SearchControlColors.PopupBorderBrushKey!)!;
+                        this.BorderThickness = new Thickness(0, 0, 0, 1);
+                        break;
+                    case VisualStyle.FullRowTransparent:
+                        // Copy the editor background so ImageThemingUtilities can theme images against it.
+                        this.Background = this._textView.Background ?? Brushes.Transparent;
+                        this.BorderBrush = (Brush)this.FindResource(SearchControlColors.PopupBorderBrushKey!)!;
+                        this.BorderThickness = new Thickness(0, 0, 0, 1);
+                        break;
+                    case VisualStyle.FullRowToolWindow:
+                        this.Background = (Brush)this.FindResource(VsBrushes.ToolWindowBackgroundKey!)!;
+                        this.BorderBrush = (Brush)this.FindResource(SearchControlColors.PopupBorderBrushKey!)!;
+                        this.BorderThickness = new Thickness(0, 0, 0, 1);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+
+                break;
+
+            case BarPosition.Bottom:
+                this.Background = (Brush)this.FindResource(VsBrushes.CommandBarGradientKey!)!;
+                this.BorderBrush = Brushes.Transparent;
+                this.BorderThickness = new Thickness(0);
+                break;
+
+            case BarPosition.BottomControl:
+                this.Background = (Brush)this.FindResource(VsBrushes.ScrollBarBackgroundKey!)!;
+                this.BorderBrush = Brushes.Transparent;
+                this.BorderThickness = new Thickness(0);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException();
         }
     }
 

--- a/src/EditorBar/Controls/EditorBarControlContainer.xaml.cs
+++ b/src/EditorBar/Controls/EditorBarControlContainer.xaml.cs
@@ -6,6 +6,7 @@
 
 using System.Windows;
 using JPSoftworks.EditorBar.Helpers;
+using JPSoftworks.EditorBar.Options;
 using JPSoftworks.EditorBar.Services.StructureProviders;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Threading;
@@ -23,6 +24,7 @@ namespace JPSoftworks.EditorBar.Controls;
 internal partial class EditorBarControlContainer : IDisposable
 {
     private readonly JoinableTaskFactory _joinableTaskFactory;
+    private readonly BarPosition _position;
     private readonly IStructureProviderService _structureProviderService;
     private readonly IWpfTextView _textView;
 
@@ -30,11 +32,13 @@ internal partial class EditorBarControlContainer : IDisposable
         IWpfTextView textView,
         JoinableTaskFactory joinableTaskFactory,
         IStructureProviderService structureProviderService,
+        BarPosition position,
         bool visible)
     {
         this._textView = textView;
         this._joinableTaskFactory = joinableTaskFactory;
         this._structureProviderService = structureProviderService;
+        this._position = position;
         this.Visibility = visible ? Visibility.Visible : Visibility.Collapsed;
         this.InitializeComponent();
         this.RebuildUI(visible);
@@ -67,7 +71,8 @@ internal partial class EditorBarControlContainer : IDisposable
                         this._textView,
                         textDocument,
                         this._joinableTaskFactory,
-                        this._structureProviderService);
+                        this._structureProviderService,
+                        this._position);
                     return;
                 }
                 catch (Exception ex)

--- a/src/EditorBar/Controls/Options/GeneralOptionsControl.xaml
+++ b/src/EditorBar/Controls/Options/GeneralOptionsControl.xaml
@@ -114,7 +114,7 @@
                                         HorizontalItemSpacing="2"
                                         IsItemsHost="True"
                                         ItemHeight="45"
-                                        ItemWidth="90"
+                                        ItemWidth="130"
                                         Orientation="Horizontal"
                                         ShouldStretchItemsToFill="True"
                                         VerticalItemSpacing="2" />

--- a/src/EditorBar/JPSoftworks.EditorBar.csproj
+++ b/src/EditorBar/JPSoftworks.EditorBar.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Commands\Settings\SettingsToggleNavigationBarCommand.cs" />
     <Compile Include="Commands\Settings\SettingsSetPositionTopCommand.cs" />
     <Compile Include="Commands\Settings\SettingsSetPositionBottomCommand.cs" />
+    <Compile Include="Commands\Settings\SettingsSetPositionBottomControlCommand.cs" />
     <Compile Include="Commands\Settings\SettingsSetDisplayNormalCommand.cs" />
     <Compile Include="Commands\Settings\SettingsSetDisplayCompactCommand.cs" />
     <Compile Include="Commands\Settings\SettingsOpenOptionsCommand.cs" />
@@ -263,6 +264,8 @@
       <DependentUpon>EditorBarControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="MefComponents\EditorBarMargin.cs" />
+    <Compile Include="MefComponents\EditorBarMarginNames.cs" />
+    <Compile Include="MefComponents\BottomControlEditorBarFactory.cs" />
     <Compile Include="Services\LocationProviders\Abstractions\GenericProjectInfo.cs" />
     <Compile Include="Services\LocationProviders\Abstractions\BaseSolutionProjectInfo.cs" />
     <Compile Include="Presentation\ContrastForegroundBrushConverter.cs" />

--- a/src/EditorBar/MefComponents/BaseEditorBarFactory.cs
+++ b/src/EditorBar/MefComponents/BaseEditorBarFactory.cs
@@ -17,10 +17,9 @@ namespace JPSoftworks.EditorBar.MefComponents;
 /// Base for a factory for creating a margin that will hold the Editor bar.
 /// </summary>
 /// <seealso cref="Microsoft.VisualStudio.Text.Editor.IWpfTextViewMarginProvider" />
-internal abstract class BaseEditorBarFactory(BarPosition targetBarPosition) : IWpfTextViewMarginProvider
+internal abstract class BaseEditorBarFactory(BarPosition targetBarPosition, string marginName)
+    : IWpfTextViewMarginProvider
 {
-    private IWpfTextView? _textView;
-
     [Import]
     private JoinableTaskContext JoinableTaskContext { get; set; } = null!;
 
@@ -38,13 +37,14 @@ internal abstract class BaseEditorBarFactory(BarPosition targetBarPosition) : IW
             return null;
         }
 
-        this._textView = wpfTextViewHost.TextView;
+        var textView = wpfTextViewHost.TextView;
 
         return new EditorBarMargin(
-            this._textView,
+            textView,
             this.JoinableTaskContext.Factory,
             this.ServiceProvider,
             this.StructureProviderService,
-            targetBarPosition);
+            targetBarPosition,
+            marginName);
     }
 }

--- a/src/EditorBar/MefComponents/BottomControlEditorBarFactory.cs
+++ b/src/EditorBar/MefComponents/BottomControlEditorBarFactory.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 // Copyright (c) Jiří Polášek. All rights reserved.
 // ------------------------------------------------------------
 
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.Utilities;
 namespace JPSoftworks.EditorBar.MefComponents;
 
 /// <summary>
-/// Specialized class of editor bar factory for creating a margin on the top of the editor.
+/// Specialized class of editor bar factory for creating a margin beside the horizontal scroll bar.
 /// </summary>
 /// <remarks>
 /// We have to have separate classes since there can't be multiple <see cref="MarginContainerAttribute" /> on a
@@ -20,10 +20,10 @@ namespace JPSoftworks.EditorBar.MefComponents;
 /// </remarks>
 /// <seealso cref="BaseEditorBarFactory" />
 [Export(typeof(IWpfTextViewMarginProvider))]
-[Name(EditorBarMarginNames.Top)]
-[MarginContainer(PredefinedMarginNames.Top)]
-[Order(After = PredefinedMarginNames.HorizontalScrollBar)]
+[Name(EditorBarMarginNames.BottomControl)]
+[Order(After = PredefinedMarginNames.ZoomControl)]
+[MarginContainer(PredefinedMarginNames.BottomControl)]
 [ContentType(StandardContentTypeNames.Text)]
 [TextViewRole(PredefinedTextViewRoles.Document)]
-internal class TopEditorBarFactory()
-    : BaseEditorBarFactory(BarPosition.Top, EditorBarMarginNames.Top);
+internal class BottomControlEditorBarFactory()
+    : BaseEditorBarFactory(BarPosition.BottomControl, EditorBarMarginNames.BottomControl);

--- a/src/EditorBar/MefComponents/BottomEditorBarFactory.cs
+++ b/src/EditorBar/MefComponents/BottomEditorBarFactory.cs
@@ -15,14 +15,15 @@ namespace JPSoftworks.EditorBar.MefComponents;
 /// Specialized class of editor bar factory for creating a margin on the bottom of the editor.
 /// </summary>
 /// <remarks>
-/// We have to have two separate classes since there can't be multiple <see cref="MarginContainerAttribute" /> on a
+/// We have to have separate classes since there can't be multiple <see cref="MarginContainerAttribute" /> on a
 /// class.
 /// </remarks>
 /// <seealso cref="BaseEditorBarFactory" />
 [Export(typeof(IWpfTextViewMarginProvider))]
-[Name("EditorBar-Bottom")]
+[Name(EditorBarMarginNames.Bottom)]
 [MarginContainer(PredefinedMarginNames.Bottom)]
 [Order(After = PredefinedMarginNames.HorizontalScrollBar)]
 [ContentType(StandardContentTypeNames.Text)]
 [TextViewRole(PredefinedTextViewRoles.Document)]
-internal class BottomEditorBarFactory() : BaseEditorBarFactory(BarPosition.Bottom);
+internal class BottomEditorBarFactory()
+    : BaseEditorBarFactory(BarPosition.Bottom, EditorBarMarginNames.Bottom);

--- a/src/EditorBar/MefComponents/EditorBarMargin.cs
+++ b/src/EditorBar/MefComponents/EditorBarMargin.cs
@@ -27,6 +27,9 @@ namespace JPSoftworks.EditorBar.MefComponents;
 /// </summary>
 internal class EditorBarMargin : IWpfTextViewMargin
 {
+    private const double BottomControlFallbackMaxWidth = 600;
+    private const double BottomControlMaxWidthRatio = 0.5;
+
     // collection of text view roles that are used in diff views
     private static readonly string[] DiffViews =
     [
@@ -38,6 +41,7 @@ internal class EditorBarMargin : IWpfTextViewMargin
 
     private readonly EditorBarControlContainer _editorBarControl;
     private readonly JoinableTaskFactory _joinableTaskFactory;
+    private readonly string _marginName;
     private readonly BarPosition _position;
     private readonly IServiceProvider _serviceProvider;
     private readonly IWpfTextView _textView;
@@ -51,7 +55,23 @@ internal class EditorBarMargin : IWpfTextViewMargin
     /// For a vertical margin this is the width of the margin, since the height will be determined by the
     /// <see cref="T:Microsoft.VisualStudio.Text.Editor.ITextView" />.
     /// </remarks>
-    public double MarginSize => this.Enabled ? this._editorBarControl.ActualHeight : 0;
+    public double MarginSize
+    {
+        get
+        {
+            if (!this.Enabled)
+            {
+                return 0;
+            }
+
+            return this._position switch
+            {
+                BarPosition.Top or BarPosition.Bottom => this._editorBarControl.ActualHeight,
+                BarPosition.BottomControl => this._editorBarControl.ActualWidth,
+                _ => throw new ArgumentOutOfRangeException(nameof(this._position), this._position, null)
+            };
+        }
+    }
 
     /// <summary>
     /// Gets a value indicating whether the margin is enabled.
@@ -71,22 +91,35 @@ internal class EditorBarMargin : IWpfTextViewMargin
     /// <param name="serviceProvider">The service provider.</param>
     /// <param name="structureProviderService">The structure provider service.</param>
     /// <param name="position">The position.</param>
+    /// <param name="marginName">The stable MEF name of this margin.</param>
     public EditorBarMargin(
         IWpfTextView textView,
         JoinableTaskFactory joinableTaskFactory,
         IServiceProvider serviceProvider,
         IStructureProviderService structureProviderService,
-        BarPosition position)
+        BarPosition position,
+        string marginName)
     {
         this._textView = textView;
         this._position = position;
+        this._marginName = marginName;
         this._joinableTaskFactory = joinableTaskFactory;
         this._editorBarControl = new EditorBarControlContainer(
             textView,
             joinableTaskFactory,
             structureProviderService,
+            position,
             false);
         this._serviceProvider = serviceProvider;
+
+        if (position == BarPosition.BottomControl)
+        {
+            // This margin shares a row with the horizontal scrollbar. Prevent it from consuming more than half of
+            // the viewport until customizable Editor Bar layouts replace this temporary sizing policy.
+            this._editorBarControl.ClipToBounds = true;
+            this.UpdateBottomControlMaxWidth();
+            this._textView.ViewportWidthChanged += this.TextViewOnViewportWidthChanged;
+        }
 
         GeneralOptionsModel.Saved += this.GeneralPageOnSaved;
         this.GeneralPageOnSaved(GeneralOptionsModel.Instance);
@@ -98,6 +131,7 @@ internal class EditorBarMargin : IWpfTextViewMargin
     public void Dispose()
     {
         GeneralOptionsModel.Saved -= this.GeneralPageOnSaved;
+        this._textView.ViewportWidthChanged -= this.TextViewOnViewportWidthChanged;
         this._editorBarControl.Dispose();
     }
 
@@ -116,15 +150,32 @@ internal class EditorBarMargin : IWpfTextViewMargin
     /// </remarks>
     public ITextViewMargin? GetTextViewMargin(string marginName)
     {
-        return marginName == "EditorBar-" + this._position ? this : null;
+        return string.Equals(marginName, this._marginName, StringComparison.OrdinalIgnoreCase) ? this : null;
     }
 
     private void GeneralPageOnSaved(GeneralOptionsModel generalOptionsModel)
     {
-        this.Enabled = generalOptionsModel.Enabled && generalOptionsModel.BarPosition == this._position;
-        this._editorBarControl.Visibility = this.Enabled && this.IsSupported(generalOptionsModel)
+        var shouldShow = generalOptionsModel.Enabled &&
+                         generalOptionsModel.BarPosition == this._position &&
+                         this.IsSupported(generalOptionsModel);
+
+        this.Enabled = shouldShow;
+        this._editorBarControl.Visibility = shouldShow
             ? Visibility.Visible
             : Visibility.Collapsed;
+    }
+
+    private void TextViewOnViewportWidthChanged(object sender, EventArgs e)
+    {
+        this.UpdateBottomControlMaxWidth();
+    }
+
+    private void UpdateBottomControlMaxWidth()
+    {
+        var viewportWidth = this._textView.ViewportWidth;
+        this._editorBarControl.MaxWidth = viewportWidth > 0
+            ? viewportWidth * BottomControlMaxWidthRatio
+            : BottomControlFallbackMaxWidth;
     }
 
     private bool IsSupported(GeneralOptionsModel generalOptionsModel)

--- a/src/EditorBar/MefComponents/EditorBarMarginNames.cs
+++ b/src/EditorBar/MefComponents/EditorBarMarginNames.cs
@@ -1,0 +1,28 @@
+// ------------------------------------------------------------
+// Copyright (c) Jiří Polášek. All rights reserved.
+// ------------------------------------------------------------
+
+#nullable enable
+
+namespace JPSoftworks.EditorBar.MefComponents;
+
+/// <summary>
+/// Defines stable MEF margin identities for Editor Bar placements.
+/// </summary>
+internal static class EditorBarMarginNames
+{
+    /// <summary>
+    /// The top Editor Bar margin name.
+    /// </summary>
+    internal const string Top = "EditorBar-Top";
+
+    /// <summary>
+    /// The bottom Editor Bar margin name.
+    /// </summary>
+    internal const string Bottom = "EditorBar-Bottom";
+
+    /// <summary>
+    /// The Editor Bar margin name in the bottom control row.
+    /// </summary>
+    internal const string BottomControl = "EditorBar-BottomControl";
+}

--- a/src/EditorBar/Options/BarPosition.cs
+++ b/src/EditorBar/Options/BarPosition.cs
@@ -19,5 +19,10 @@ public enum BarPosition
     /// <summary>
     /// The bottom of the text view.
     /// </summary>
-    Bottom = 1
+    Bottom = 1,
+
+    /// <summary>
+    /// In the bottom editor controls, after the zoom control.
+    /// </summary>
+    BottomControl = 2
 }

--- a/src/EditorBar/VSCommandTable.cs
+++ b/src/EditorBar/VSCommandTable.cs
@@ -104,6 +104,7 @@ namespace JPSoftworks.EditorBar
         public const int EditorBarSettings_ToggleNavigationBarCommand = 0x8021;
         public const int EditorBarSettings_PositionTopCommand = 0x8022;
         public const int EditorBarSettings_PositionBottomCommand = 0x8023;
+        public const int EditorBarSettings_PositionBottomControlCommand = 0x8027;
         public const int EditorBarSettings_DisplayNormalCommand = 0x8024;
         public const int EditorBarSettings_DisplayCompactCommand = 0x8025;
         public const int EditorBarSettings_OpenOptionsCommand = 0x8026;

--- a/src/EditorBar/VSCommandTable.vsct
+++ b/src/EditorBar/VSCommandTable.vsct
@@ -671,8 +671,8 @@
 				<CommandFlag>NoKeyCustomize</CommandFlag>
 				<CommandFlag>NoCustomize</CommandFlag>
 				<Strings>
-					<ButtonText>Horizontal Scroll Bar</ButtonText>
-					<CommandName>Position: Horizontal Scroll Bar</CommandName>
+					<ButtonText>Bottom (next to Zoom)</ButtonText>
+					<CommandName>Position: Bottom (next to Zoom)</CommandName>
 					<CanonicalName>EditorBar.Settings.PositionBottomControl</CanonicalName>
 					<LocCanonicalName>EditorBar.Settings.PositionBottomControl</LocCanonicalName>
 				</Strings>

--- a/src/EditorBar/VSCommandTable.vsct
+++ b/src/EditorBar/VSCommandTable.vsct
@@ -666,6 +666,18 @@
 				</Strings>
 			</Button>
 
+			<Button guid="EditorBarCmdSet" id="EditorBarSettings_PositionBottomControlCommand" priority="0x0300" type="Button">
+				<Parent guid="EditorBarCmdSet" id="EditorBarSettingsMenu_PositionSubMenuGroup" />
+				<CommandFlag>NoKeyCustomize</CommandFlag>
+				<CommandFlag>NoCustomize</CommandFlag>
+				<Strings>
+					<ButtonText>Horizontal Scroll Bar</ButtonText>
+					<CommandName>Position: Horizontal Scroll Bar</CommandName>
+					<CanonicalName>EditorBar.Settings.PositionBottomControl</CanonicalName>
+					<LocCanonicalName>EditorBar.Settings.PositionBottomControl</LocCanonicalName>
+				</Strings>
+			</Button>
+
 			<Button guid="EditorBarCmdSet" id="EditorBarSettings_DisplayNormalCommand" priority="0x0100" type="Button">
 				<Parent guid="EditorBarCmdSet" id="EditorBarSettingsMenu_DisplayModeSubMenuGroup" />
 				<CommandFlag>NoKeyCustomize</CommandFlag>
@@ -988,6 +1000,7 @@
 			<IDSymbol name="EditorBarSettings_ToggleNavigationBarCommand" value="0x8021" />
 			<IDSymbol name="EditorBarSettings_PositionTopCommand" value="0x8022" />
 			<IDSymbol name="EditorBarSettings_PositionBottomCommand" value="0x8023" />
+			<IDSymbol name="EditorBarSettings_PositionBottomControlCommand" value="0x8027" />
 			<IDSymbol name="EditorBarSettings_DisplayNormalCommand" value="0x8024" />
 			<IDSymbol name="EditorBarSettings_DisplayCompactCommand" value="0x8025" />
 			<IDSymbol name="EditorBarSettings_OpenOptionsCommand" value="0x8026" />

--- a/src/EditorBar/ViewModels/OptionsPageViewModel.cs
+++ b/src/EditorBar/ViewModels/OptionsPageViewModel.cs
@@ -66,7 +66,8 @@ public class OptionsPageViewModel : ObservableObject
     public ObservableCollection<EnumViewModel<BarPosition>> BarPositions { get; } =
     [
         new(BarPosition.Top, "Top"),
-        new(BarPosition.Bottom, "Bottom")
+        new(BarPosition.Bottom, "Bottom"),
+        new(BarPosition.BottomControl, "Horizontal scroll bar")
     ];
 
     /// <summary>

--- a/src/EditorBar/ViewModels/OptionsPageViewModel.cs
+++ b/src/EditorBar/ViewModels/OptionsPageViewModel.cs
@@ -67,7 +67,7 @@ public class OptionsPageViewModel : ObservableObject
     [
         new(BarPosition.Top, "Top"),
         new(BarPosition.Bottom, "Bottom"),
-        new(BarPosition.BottomControl, "Horizontal scroll bar")
+        new(BarPosition.BottomControl, "Bottom (next to Zoom)")
     ];
 
     /// <summary>


### PR DESCRIPTION
This PR adds a new Editor Bar position, between zoom control and horizontal scrollbar.

<img width="1515" height="306" alt="image" src="https://github.com/user-attachments/assets/484c26ac-db34-418a-afbd-27faa2e797b0" />

Closes: #154 